### PR TITLE
moved stylesheets to index only, fixing weird styling issue

### DIFF
--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -1,3 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/jquery/1/jquery.min.js"></script>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/bootstrap/3/css/bootstrap.css" />
+    <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap.daterangepicker/2/daterangepicker.js"></script>
+    <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/bootstrap.daterangepicker/2/daterangepicker.css" />
+  </head>
+  <div class="container pt-4">
+    <div class="d-flex justify-content-center">
+      <h1>Entry History</h1>
+    </div>
+    <%= render "search" %>
+    <%# This is the end of the dropdown code %>
+    <%# <%= render "search-category" %>  <%# Change render name to correct one later  %>
+    <div class='entries'>
+      <%= link_to 'generate pdf', entries_path(format: :pdf), class: 'btn btn-warning p-2 my-3'   %>
+      <%= render 'entries', entries: @entries %>
+    </div>
+  </div>
+</body>
+</html>
 <div class="container pt-4">
   <div class="d-flex justify-content-center">
     <h1>Entry History</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,13 +9,6 @@
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://unpkg.com/cal-heatmap/dist/cal-heatmap.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.2/css/all.css">
-    <%# Test for code from here %>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/jquery/1/jquery.min.js"></script>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/bootstrap/3/css/bootstrap.css" />
-    <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap.daterangepicker/2/daterangepicker.js"></script>
-    <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/bootstrap.daterangepicker/2/daterangepicker.css" />
-    <%#  Test for code end here%>
   </head>
   <body><%= render "shared/navbar" %>
     <%= render "shared/flashes" %>


### PR DESCRIPTION
I moved the date frame stylesheets from the application to the index page since it seems it was messing with the entire css styling. 